### PR TITLE
changes during debug with aws glue container.

### DIFF
--- a/etl_gphl_cre_alert.py
+++ b/etl_gphl_cre_alert.py
@@ -13,7 +13,7 @@ from pyspark.sql import SparkSession
 
 # for our purposes here, the spark and glue context are only (currently) needed
 # to get the logger.
-spark_ctx = SparkSession.builder.getOrCreate()
+spark_ctx = SparkSession.builder.getOrCreate()  # pyright: ignore
 glue_ctx = GlueContext(spark_ctx)
 logger = glue_ctx.get_logger()
 


### PR DESCRIPTION
# TO TEST

## IFF you can run with the AWS glue docker container, you can test that this does what it says. 

The general pattern is:
* log into the aws account with `aws-adfs` ([instructions here](https://github.com/cape-ph/cape-gtri-aws-cli))
* use a browser to 
  * go to s3 in the [gtri aws console](https://aws.gtri.gatech.edu)
  * go to the `cdld-hai-clean-bucket-2771944` bucket
  * ensure there is no `GPHL CRE Alert Example.csv` file in the bucket (delete it if there is)
* start up the docker container ([instructions here](https://gtri.app.box.com/file/1537157250770))
* ensure that python-docx is installed in it
* make a new pyspark notebook
* add a cell for the input args like this
```
# setup for the notebook case.
import sys

# these are the arguments the ETL will expect to be defined. These need to resolve to real things in AWS
sys.argv.append("--RAW_BUCKET_NAME=cdld-hai-raw-bucket-25a6dc6")
sys.argv.append("--ALERT_OBJ_KEY=GPHL CRE Alert Example.docx")
sys.argv.append("--CLEAN_BUCKET_NAME=cdld-hai-clean-bucket-2771944")
```
* add another cell with the contents of the `etl_gphl_cre_alert.py` from this repo
* execute the cell with the args and wait for pyspark to start iup
* execute the cell with the etl and wait for output (there will be a warning, but no errors)
* look in the clean bucket noted above for the file `GPHL CRE Alert Example.csv` and ensure its contents are as expected

## if you cannot run with the AWS glue docker container, visual inspection is the best you can do
