### PR TITLE
ci: add versioning to org level ci/cd

### DIFF
--- a/.github/workflows/cape.yml
+++ b/.github/workflows/cape.yml
@@ -7,9 +7,9 @@ on:
 jobs:
     python:
         name: Python
-        uses: cape-ph/.github/.github/workflows/python_checks.yml@main
+        uses: cape-ph/.github/.github/workflows/python_checks.yml@v1
         with:
             pytest: false
     general:
         name: General
-        uses: cape-ph/.github/.github/workflows/general_checks.yml@main
+        uses: cape-ph/.github/.github/workflows/general_checks.yml@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
     Release:
-        uses: cape-ph/.github/.github/workflows/release.yml@main
+        uses: cape-ph/.github/.github/workflows/release.yml@v1
         secrets: inherit


### PR DESCRIPTION
pin org level CI/CD to major releases to avoid breaking changes breaking our CI/CD